### PR TITLE
fix: makes it usable as node module

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var extend = require('xtend')
 var debug = require('debug')('electron-microscope')
 var createBridge = require('./bridge.js')
 
-var clientBundle = fs.readFileSync('./socket-client-bundle.js').toString()
+var clientBundle = fs.readFileSync(path.join(__dirname, './socket-client-bundle.js')).toString()
 
 module.exports = Microscope
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "electron-microscope": "cli.js"
   },
   "scripts": {
-    "bundle": "browserify socket-client.js -o socket-client-bundle.js",
+    "postinstall": "browserify socket-client.js -o socket-client-bundle.js",
     "rmcache": "rm ~/Library/Application\\ Support/Electron/Local\\ Storage/*",
     "test": "node test/test.js"
   },
   "dependencies": {
+    "browserify": "^12.0.1",
     "debug": "^2.2.0",
     "debug-stream": "^2.0.2",
     "duplexify": "^3.4.2",


### PR DESCRIPTION
This allows electron-microscope to be used from another electron-app as a dependency.
